### PR TITLE
Added the ability to use #[default] and added Default in the derive trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,8 +339,8 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
             ident_token("Eq"),
             punct_token(','),
             ident_token("Hash"),
-            punct_token(',')
-            ident_token("Default")
+            punct_token(','),
+            ident_token("Default"),
         ]),
     ]));
     out.push(ident_token("pub"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
         None => error!("Expected ';' but got end of macro"),
     }
 
-    let mut triples = {
+    let triples = {
         // Each triple contains information about a variant of the enum.
         // (Attributes, Identifier, Value-Expression)
         let mut triples = Vec::<(TokenStream, Ident, TokenTree)>::new();
@@ -321,6 +321,7 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
             offset += 1;
             triples.push((variant_attributes, variant_name, value));
         }
+        check_for_default(&mut triples); // make sure there's a default, if the user didn't specify one
         triples
     };
 
@@ -341,7 +342,6 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
         ident_token("repr"),
         paren_token(repr_type.clone()),
     ]));
-    check_for_default(&mut triples); // make sure there's a default, if the user didn't specify one
     // #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     out.push(punct_token('#'));
     out.push(bracket_token(vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,25 @@ fn concat<T>(mut v1: Vec<T>, mut v2: Vec<T>) -> Vec<T> {
     v1
 }
 
+fn check_for_default(triples: &mut Vec<(TokenStream, Ident, TokenTree)>) {
+    let mut default_position: Option<usize> = None;
+    for (attributes, variant_name, variant_value) in triples.into_iter() {
+        if attributes.to_string().contains("default") {
+            if default_position.is_some() {
+                // error!("Multiple variants marked as default");
+            }
+            default_position = Some(variant_value.to_string().parse::<usize>().unwrap());
+        }
+    }
+    if !default_position.is_some() {
+        // No default specified, so we'll just use the first variant
+        triples[0].0.extend(vec![
+            punct_token('#'),
+            bracket_token(vec![ident_token("default")]).into(),
+        ]);
+    }
+}
+
 #[proc_macro]
 pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
     let mut iter = tokens.into_iter();
@@ -236,7 +255,7 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
         None => error!("Expected ';' but got end of macro"),
     }
 
-    let triples = {
+    let mut triples = {
         // Each triple contains information about a variant of the enum.
         // (Attributes, Identifier, Value-Expression)
         let mut triples = Vec::<(TokenStream, Ident, TokenTree)>::new();
@@ -322,7 +341,7 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
         ident_token("repr"),
         paren_token(repr_type.clone()),
     ]));
-
+    check_for_default(&mut triples); // make sure there's a default, if the user didn't specify one
     // #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     out.push(punct_token('#'));
     out.push(bracket_token(vec![
@@ -343,6 +362,7 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
             ident_token("Default"),
         ]),
     ]));
+
     out.push(ident_token("pub"));
     out.push(ident_token("enum"));
     out.push(TokenTree::Ident(enum_identifier.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ fn concat<T>(mut v1: Vec<T>, mut v2: Vec<T>) -> Vec<T> {
 
 fn check_for_default(triples: &mut Vec<(TokenStream, Ident, TokenTree)>) {
     let mut default_position: Option<usize> = None;
-    for (attributes, variant_name, variant_value) in triples.into_iter() {
+    for (attributes, _variant_name, variant_value) in triples.into_iter() {
         if attributes.to_string().contains("default") {
             if default_position.is_some() {
                 // error!("Multiple variants marked as default");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,8 @@ pub fn primitive_enum(tokens: TokenStream) -> TokenStream {
             ident_token("Eq"),
             punct_token(','),
             ident_token("Hash"),
+            punct_token(',')
+            ident_token("Default")
         ]),
     ]));
     out.push(ident_token("pub"));

--- a/tests/sample.rs
+++ b/tests/sample.rs
@@ -196,4 +196,22 @@ mod tests {
         assert_eq!(MarkerType::from_name("Markerboxes"), Some(MarkerType::Markerboxes));
         assert_eq!(MarkerType::from_name("Markerpitlane"), Some(MarkerType::Markerpitlane));
     }
+
+    primitive_enum! { MarkerType2 u32 ;
+        A, // 0
+        B, // 1
+        C, // 2
+        D, // 3
+        E, // 4
+        #[default]
+        F, // 5
+        G, // 6
+    }
+
+    #[test]
+    fn test_enum_default() {
+        assert_eq!(MarkerType2::default(), MarkerType2::F);
+        assert_eq!(MarkerType2::from(0), Some(MarkerType2::A));
+        assert_eq!(MyEnum::default(), MyEnum::A);
+    }
 }


### PR DESCRIPTION
This adds the ability to use `#[default]` when declaring the enum and adds `Default` to the derives for the enum
This allows you to derive the trait `Default` for structs that contain a enum generated using this macro